### PR TITLE
feat: go release improvements

### DIFF
--- a/go-bulk-release-cli/src/main/java/org/qubership/cloud/actions/go/GoBulkReleaseCli.java
+++ b/go-bulk-release-cli/src/main/java/org/qubership/cloud/actions/go/GoBulkReleaseCli.java
@@ -118,7 +118,7 @@ public class GoBulkReleaseCli implements Runnable {
             if (normalizedLtsBranchName == null) {
                 throw new IllegalArgumentException("--ltsBranchName is required when --ltsRelease is set");
             }
-            if (!normalizedLtsBranchName.matches("lts/\\d{2}\\.\\d+")) {
+            if (!normalizedLtsBranchName.matches("lts/\\d{2}\\.\\d")) {
                 throw new IllegalArgumentException("--ltsBranchName must match pattern 'lts/YY.N' (e.g. lts/26.2), got: " + normalizedLtsBranchName);
             }
         }

--- a/go-bulk-release-cli/src/main/java/org/qubership/cloud/actions/go/GoBulkReleaseCli.java
+++ b/go-bulk-release-cli/src/main/java/org/qubership/cloud/actions/go/GoBulkReleaseCli.java
@@ -73,6 +73,12 @@ public class GoBulkReleaseCli implements Runnable {
     @CommandLine.Option(names = {"--branch"}, defaultValue = "", description = "branch to check out all repositories from; when set, only patch version bumps are allowed")
     private String branch;
 
+    @CommandLine.Option(names = {"--ltsRelease"}, arity = "0", defaultValue = "false", description = "enable LTS release mode: create LTS branches and add technical commit to main after release")
+    private boolean ltsRelease;
+
+    @CommandLine.Option(names = {"--ltsBranchName"}, defaultValue = "", description = "LTS branch name to create, e.g. lts/26.2 (required when --ltsRelease is set)")
+    private String ltsBranchName;
+
     public static void main(String... args) {
         CommandLine commandLine = new CommandLine(new GoBulkReleaseCli());
         int exitCode = commandLine.execute(args);
@@ -100,6 +106,22 @@ public class GoBulkReleaseCli implements Runnable {
         }
 
         String normalizedBranch = (branch == null || branch.isBlank()) ? null : branch.strip();
+        String normalizedLtsBranchName = (ltsBranchName == null || ltsBranchName.isBlank()) ? null : ltsBranchName.strip();
+
+        if (ltsRelease) {
+            if (!repositoriesToReleaseFrom.stream().filter(Objects::nonNull).toList().isEmpty()) {
+                throw new IllegalArgumentException("--ltsRelease cannot be combined with --repositoriesToReleaseFrom: LTS release must include all repositories");
+            }
+            if (normalizedBranch != null) {
+                throw new IllegalArgumentException("--ltsRelease cannot be combined with --branch: LTS release must run from the default branch");
+            }
+            if (normalizedLtsBranchName == null) {
+                throw new IllegalArgumentException("--ltsBranchName is required when --ltsRelease is set");
+            }
+            if (!normalizedLtsBranchName.matches("lts/\\d{2}\\.\\d+")) {
+                throw new IllegalArgumentException("--ltsBranchName must match pattern 'lts/YY.N' (e.g. lts/26.2), got: " + normalizedLtsBranchName);
+            }
+        }
 
         GitConfig gitConfig = GitConfig.builder()
                 .url(gitURL)
@@ -122,6 +144,8 @@ public class GoBulkReleaseCli implements Runnable {
                 .dependencyGraphFile(dependencyGraphFile)
                 .gavsResultFile(gavsResultFile)
                 .branch(normalizedBranch)
+                .ltsRelease(ltsRelease)
+                .ltsBranchName(normalizedLtsBranchName)
                 .build();
     }
 }

--- a/go-bulk-release-cli/src/main/java/org/qubership/cloud/actions/go/GoBulkReleaseCli.java
+++ b/go-bulk-release-cli/src/main/java/org/qubership/cloud/actions/go/GoBulkReleaseCli.java
@@ -70,6 +70,9 @@ public class GoBulkReleaseCli implements Runnable {
     @CommandLine.Option(names = {"--skipGoProxy"}, arity = "0", defaultValue = "false", description = "skip publish modules to go proxy")
     private boolean skipGoProxy;
 
+    @CommandLine.Option(names = {"--branch"}, defaultValue = "", description = "branch to check out all repositories from; when set, only patch version bumps are allowed")
+    private String branch;
+
     public static void main(String... args) {
         CommandLine commandLine = new CommandLine(new GoBulkReleaseCli());
         int exitCode = commandLine.execute(args);
@@ -96,6 +99,8 @@ public class GoBulkReleaseCli implements Runnable {
             throw new IllegalArgumentException("--repositories property cannot be empty");
         }
 
+        String normalizedBranch = (branch == null || branch.isBlank()) ? null : branch.strip();
+
         GitConfig gitConfig = GitConfig.builder()
                 .url(gitURL)
                 .username(gitUsername)
@@ -107,7 +112,6 @@ public class GoBulkReleaseCli implements Runnable {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-
         return Config.builder(baseDir, goProxyDir, gitConfig, repositories)
                 .repositoriesToReleaseFrom(repositoriesToReleaseFrom)
                 .skipTests(skipTests)
@@ -117,6 +121,7 @@ public class GoBulkReleaseCli implements Runnable {
                 .resultOutputFile(resultOutputFile)
                 .dependencyGraphFile(dependencyGraphFile)
                 .gavsResultFile(gavsResultFile)
+                .branch(normalizedBranch)
                 .build();
     }
 }

--- a/go-bulk-release-cli/src/main/java/org/qubership/cloud/actions/go/GoBulkReleaseCli.java
+++ b/go-bulk-release-cli/src/main/java/org/qubership/cloud/actions/go/GoBulkReleaseCli.java
@@ -99,9 +99,7 @@ public class GoBulkReleaseCli implements Runnable {
     }
 
     private Config prepareConfig() {
-        if (repositories.stream()
-                .filter(Objects::nonNull)
-                .toList().isEmpty()) {
+        if (repositories.stream().noneMatch(Objects::nonNull)) {
             throw new IllegalArgumentException("--repositories property cannot be empty");
         }
 
@@ -109,7 +107,7 @@ public class GoBulkReleaseCli implements Runnable {
         String normalizedLtsBranchName = (ltsBranchName == null || ltsBranchName.isBlank()) ? null : ltsBranchName.strip();
 
         if (ltsRelease) {
-            if (!repositoriesToReleaseFrom.stream().filter(Objects::nonNull).toList().isEmpty()) {
+            if (repositoriesToReleaseFrom.stream().anyMatch(Objects::nonNull)) {
                 throw new IllegalArgumentException("--ltsRelease cannot be combined with --repositoriesToReleaseFrom: LTS release must include all repositories");
             }
             if (normalizedBranch != null) {

--- a/go-bulk-release/pom.xml
+++ b/go-bulk-release/pom.xml
@@ -64,6 +64,13 @@
             <artifactId>jgrapht-io</artifactId>
             <version>${org.jgrapht.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/GitService.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/GitService.java
@@ -6,6 +6,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.TagOpt;
 import org.qubership.cloud.actions.go.model.GitConfig;
 import org.qubership.cloud.actions.go.model.UnexpectedException;
@@ -148,7 +149,7 @@ public class GitService {
         try (Git git = Git.open(repository)) {
             git.push()
                     .setCredentialsProvider(config.getCredentialsProvider())
-                    .setRefSpecs(new org.eclipse.jgit.transport.RefSpec(branchName + ":" + branchName))
+                    .setRefSpecs(new RefSpec(branchName + ":" + branchName))
                     .call();
         } catch (Exception e) {
             throw new UnexpectedException(e);

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/GitService.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/GitService.java
@@ -154,7 +154,7 @@ public class GitService {
         try (Git git = Git.open(repository)) {
             Iterable<PushResult> results = git.push()
                     .setCredentialsProvider(config.getCredentialsProvider())
-                    .setRefSpecs(new RefSpec(branchName + ":" + branchName))
+                    .setRefSpecs(new RefSpec("refs/heads/" + branchName + ":refs/heads/" + branchName))
                     .call();
             checkPushResults(results, repository.getAbsolutePath());
         } catch (UnexpectedException e) {
@@ -166,8 +166,10 @@ public class GitService {
     }
 
     private void checkPushResults(Iterable<PushResult> results, String repositoryPath) {
+        boolean anyUpdateChecked = false;
         for (PushResult result : results) {
             for (RemoteRefUpdate update : result.getRemoteUpdates()) {
+                anyUpdateChecked = true;
                 RemoteRefUpdate.Status status = update.getStatus();
                 if (status != RemoteRefUpdate.Status.OK && status != RemoteRefUpdate.Status.UP_TO_DATE) {
                     throw new UnexpectedException(
@@ -175,6 +177,11 @@ public class GitService {
                                     .formatted(repositoryPath, status, update.getMessage()));
                 }
             }
+        }
+        if (!anyUpdateChecked) {
+            throw new UnexpectedException(
+                    "Push to repository '%s' produced no ref updates — remote may have rejected the connection."
+                            .formatted(repositoryPath));
         }
     }
 

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/GitService.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/GitService.java
@@ -6,7 +6,9 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.eclipse.jgit.transport.TagOpt;
 import org.qubership.cloud.actions.go.model.GitConfig;
 import org.qubership.cloud.actions.go.model.UnexpectedException;
@@ -134,11 +136,14 @@ public class GitService {
 
     public void pushChanges(File repository) {
         try (Git git = Git.open(repository)) {
-            git.push()
+            Iterable<PushResult> results = git.push()
                     .setCredentialsProvider(config.getCredentialsProvider())
                     .setPushAll()
                     .setPushTags()
                     .call();
+            checkPushResults(results, repository.getAbsolutePath());
+        } catch (UnexpectedException e) {
+            throw e;
         } catch (Exception e) {
             throw new UnexpectedException(e);
         }
@@ -147,14 +152,30 @@ public class GitService {
 
     public void pushBranch(File repository, String branchName) {
         try (Git git = Git.open(repository)) {
-            git.push()
+            Iterable<PushResult> results = git.push()
                     .setCredentialsProvider(config.getCredentialsProvider())
                     .setRefSpecs(new RefSpec(branchName + ":" + branchName))
                     .call();
+            checkPushResults(results, repository.getAbsolutePath());
+        } catch (UnexpectedException e) {
+            throw e;
         } catch (Exception e) {
             throw new UnexpectedException(e);
         }
         log.info("Pushed branch '{}' to git: repo: {}", branchName, repository.getAbsoluteFile());
+    }
+
+    private void checkPushResults(Iterable<PushResult> results, String repositoryPath) {
+        for (PushResult result : results) {
+            for (RemoteRefUpdate update : result.getRemoteUpdates()) {
+                RemoteRefUpdate.Status status = update.getStatus();
+                if (status != RemoteRefUpdate.Status.OK && status != RemoteRefUpdate.Status.UP_TO_DATE) {
+                    throw new UnexpectedException(
+                            "Push to repository '%s' was rejected by remote. Status: %s, message: %s"
+                                    .formatted(repositoryPath, status, update.getMessage()));
+                }
+            }
+        }
     }
 
     private List<String> getDiff(Git git, DiffEntry.ChangeType changeType) throws GitAPIException {

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/GitService.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/GitService.java
@@ -144,6 +144,18 @@ public class GitService {
         log.info("Pushed to git: repo: {}", repository.getAbsoluteFile());
     }
 
+    public void pushBranch(File repository, String branchName) {
+        try (Git git = Git.open(repository)) {
+            git.push()
+                    .setCredentialsProvider(config.getCredentialsProvider())
+                    .setRefSpecs(new org.eclipse.jgit.transport.RefSpec(branchName + ":" + branchName))
+                    .call();
+        } catch (Exception e) {
+            throw new UnexpectedException(e);
+        }
+        log.info("Pushed branch '{}' to git: repo: {}", branchName, repository.getAbsoluteFile());
+    }
+
     private List<String> getDiff(Git git, DiffEntry.ChangeType changeType) throws GitAPIException {
         List<DiffEntry> diff = git.diff().call();
         return diff.stream().filter(d -> d.getChangeType() == changeType).map(DiffEntry::getNewPath).toList();

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
@@ -257,7 +257,7 @@ public class ReleaseRunner {
     void performLtsSteps(List<RepositoryRelease> allReleases) {
         log.info("=== Running 'LTS STEPS' for {} repositories ===", allReleases.size());
         ParallelExecutor.forEachIn(allReleases)
-                .inParallelOn(allReleases.size())
+                .inParallelOn(1)
                 .execute(release -> {
                     performLtsStepsForRepository(release);
                     return release;

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
@@ -268,14 +268,13 @@ public class ReleaseRunner {
     void performLtsStepsForRepository(RepositoryRelease release) {
         log.info("--- LTS STEPS {} ---", release.getRepository().getUrl());
 
-        String ltsBranchName = config.getLtsBranchName();
-        createLtsBranch(release, ltsBranchName, DEFAULT_BRANCH);
-        makeTechnicalCommit(release, DEFAULT_BRANCH);
+        createLtsBranch(release, config.getLtsBranchName());
+        makeTechnicalCommit(release);
 
         log.info("--- LTS STEPS DONE FOR {} ---", release.getRepository().getUrl());
     }
 
-    void createLtsBranch(RepositoryRelease release, String ltsBranchName, String originalBranch) {
+    void createLtsBranch(RepositoryRelease release, String ltsBranchName) {
         File repoDir = release.getRepository().getRepositoryDirFile();
         log.info("--- CREATE LTS BRANCH '{}' for {} ---", ltsBranchName, release.getRepository().getUrl());
         try {
@@ -287,24 +286,24 @@ public class ReleaseRunner {
         }
         gitService.pushBranch(repoDir, ltsBranchName);
         try {
-            CommandRunner.exec(repoDir, "git", "checkout", originalBranch);
+            CommandRunner.exec(repoDir, "git", "checkout", DEFAULT_BRANCH);
         } catch (CommandExecutionException e) {
             throw new ReleaseTerminationException(
                     "Failed to switch back to branch '%s' in repository %s."
-                            .formatted(originalBranch, release.getRepository().getUrl()), e);
+                            .formatted(DEFAULT_BRANCH, release.getRepository().getUrl()), e);
         }
     }
 
-    void makeTechnicalCommit(RepositoryRelease release, String originalBranch) {
+    void makeTechnicalCommit(RepositoryRelease release) {
         File repoDir = release.getRepository().getRepositoryDirFile();
-        log.info("--- TECHNICAL COMMIT IN '{}' for {} ---", originalBranch, release.getRepository().getUrl());
+        log.info("--- TECHNICAL COMMIT IN '{}' for {} ---", DEFAULT_BRANCH, release.getRepository().getUrl());
         try {
             CommandRunner.exec(repoDir, "git", "commit", "--allow-empty", "-m", "feat: technical commit for bump minor version");
         } catch (CommandExecutionException e) {
             throw new ReleaseTerminationException(
                     "Failed to create technical commit in repository %s.".formatted(release.getRepository().getUrl()), e);
         }
-        gitService.pushBranch(repoDir, originalBranch);
+        gitService.pushBranch(repoDir, DEFAULT_BRANCH);
     }
 
     Result getResult(Config config, DependencyGraph dependencyGraph, List<RepositoryRelease> allReleases) {

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
@@ -105,7 +105,7 @@ public class ReleaseRunner {
         ReleaseVersion releaseVersion = resolveReleaseVersion(repository);
         log.info("Release version: {}", releaseVersion);
 
-        if (releaseVersion.isMajorUpdate()) {
+        if (releaseVersion.isMajorUpdate() && config.getBranch() == null) {
             updateMajorVersion(repository, releaseVersion);
         }
 
@@ -135,7 +135,15 @@ public class ReleaseRunner {
     ReleaseVersion resolveReleaseVersion(RepositoryInfo repository) {
         log.info("--- CALCULATE RELEASE VERSION {} ---", repository.getUrl());
 
-        return semanticReleaseService.resolveReleaseVersion(repository);
+        ReleaseVersion releaseVersion = semanticReleaseService.resolveReleaseVersion(repository);
+
+        if (config.getBranch() != null && !releaseVersion.isPatchOnlyUpdate()) {
+            throw new ReleaseTerminationException(
+                    "Branch release requires a patch-only version bump, but semantic-release calculated %s → %s for repository %s. The branch contains feat: or BREAKING CHANGE commits."
+                            .formatted(releaseVersion.getCurrentVersion(), releaseVersion.getNewVersion(), repository.getUrl()));
+        }
+
+        return releaseVersion;
     }
 
     void updateMajorVersion(RepositoryInfo repository, ReleaseVersion releaseVersion) {

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
@@ -14,6 +14,7 @@ import org.qubership.cloud.actions.go.util.CommandExecutionException;
 import org.qubership.cloud.actions.go.util.CommandRunner;
 import org.qubership.cloud.actions.go.util.ParallelExecutor;
 
+import java.io.File;
 import java.util.*;
 import java.util.function.Predicate;
 
@@ -53,6 +54,10 @@ public class ReleaseRunner {
 
         if (!config.isDryRun()) {
             performRelease(config, dependencyGraph, preparedReleases);
+
+            if (config.isLtsRelease()) {
+                performLtsSteps(preparedReleases);
+            }
         }
 
         return getResult(config, dependencyGraph, preparedReleases);
@@ -248,12 +253,79 @@ public class ReleaseRunner {
         semanticReleaseService.release(repository);
     }
 
+    void performLtsSteps(List<RepositoryRelease> allReleases) {
+        log.info("=== Running 'LTS STEPS' for {} repositories ===", allReleases.size());
+        ParallelExecutor.forEachIn(allReleases)
+                .inParallelOn(allReleases.size())
+                .execute(release -> {
+                    performLtsStepsForRepository(release);
+                    return release;
+                });
+        log.info("=== 'LTS STEPS' completed ===");
+    }
+
+    void performLtsStepsForRepository(RepositoryRelease release) {
+        File repoDir = release.getRepository().getRepositoryDirFile();
+        String ltsBranchName = config.getLtsBranchName();
+        log.info("--- LTS STEPS {} ---", release.getRepository().getUrl());
+
+        String originalBranch = getCurrentBranch(repoDir);
+
+        createLtsBranch(release, ltsBranchName, originalBranch);
+        makeTechnicalCommit(release, originalBranch);
+
+        log.info("--- LTS STEPS DONE FOR {} ---", release.getRepository().getUrl());
+    }
+
+    void createLtsBranch(RepositoryRelease release, String ltsBranchName, String originalBranch) {
+        File repoDir = release.getRepository().getRepositoryDirFile();
+        log.info("--- CREATE LTS BRANCH '{}' for {} ---", ltsBranchName, release.getRepository().getUrl());
+        try {
+            CommandRunner.exec(repoDir, "git", "checkout", "-b", ltsBranchName);
+        } catch (CommandExecutionException e) {
+            throw new ReleaseTerminationException(
+                    "Failed to create LTS branch '%s' in repository %s. The branch may already exist."
+                            .formatted(ltsBranchName, release.getRepository().getUrl()), e);
+        }
+        gitService.pushBranch(repoDir, ltsBranchName);
+        try {
+            CommandRunner.exec(repoDir, "git", "checkout", originalBranch);
+        } catch (CommandExecutionException e) {
+            throw new ReleaseTerminationException(
+                    "Failed to switch back to branch '%s' in repository %s."
+                            .formatted(originalBranch, release.getRepository().getUrl()), e);
+        }
+    }
+
+    void makeTechnicalCommit(RepositoryRelease release, String originalBranch) {
+        File repoDir = release.getRepository().getRepositoryDirFile();
+        log.info("--- TECHNICAL COMMIT IN '{}' for {} ---", originalBranch, release.getRepository().getUrl());
+        try {
+            CommandRunner.exec(repoDir, "git", "commit", "--allow-empty", "-m", "feat: technical commit for bump minor version");
+        } catch (CommandExecutionException e) {
+            throw new ReleaseTerminationException(
+                    "Failed to create technical commit in repository %s.".formatted(release.getRepository().getUrl()), e);
+        }
+        gitService.pushBranch(repoDir, originalBranch);
+    }
+
+    String getCurrentBranch(File repoDir) {
+        try {
+            return CommandRunner.execWithResult(repoDir, "git", "symbolic-ref", "--short", "HEAD")
+                    .stream().findFirst().map(String::strip).orElse("main");
+        } catch (CommandExecutionException e) {
+            return "main";
+        }
+    }
+
     Result getResult(Config config, DependencyGraph dependencyGraph, List<RepositoryRelease> allReleases) {
         Result result = new Result();
         result.setDependencyGraph(dependencyGraph);
         result.setDependenciesDot(dependencyGraph.generateDotFile());
         result.setDryRun(config.isDryRun());
         result.setReleases(allReleases);
+        result.setLtsRelease(config.isLtsRelease() && !config.isDryRun());
+        result.setLtsBranchName(config.getLtsBranchName());
         return result;
     }
 

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/ReleaseRunner.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 @Slf4j
 public class ReleaseRunner {
     private static final YAMLMapper YAML_MAPPER = new YAMLMapper();
+    private static final String DEFAULT_BRANCH = "main";
 
     private final Config config;
     private final GitService gitService;
@@ -265,14 +266,11 @@ public class ReleaseRunner {
     }
 
     void performLtsStepsForRepository(RepositoryRelease release) {
-        File repoDir = release.getRepository().getRepositoryDirFile();
-        String ltsBranchName = config.getLtsBranchName();
         log.info("--- LTS STEPS {} ---", release.getRepository().getUrl());
 
-        String originalBranch = getCurrentBranch(repoDir);
-
-        createLtsBranch(release, ltsBranchName, originalBranch);
-        makeTechnicalCommit(release, originalBranch);
+        String ltsBranchName = config.getLtsBranchName();
+        createLtsBranch(release, ltsBranchName, DEFAULT_BRANCH);
+        makeTechnicalCommit(release, DEFAULT_BRANCH);
 
         log.info("--- LTS STEPS DONE FOR {} ---", release.getRepository().getUrl());
     }
@@ -307,15 +305,6 @@ public class ReleaseRunner {
                     "Failed to create technical commit in repository %s.".formatted(release.getRepository().getUrl()), e);
         }
         gitService.pushBranch(repoDir, originalBranch);
-    }
-
-    String getCurrentBranch(File repoDir) {
-        try {
-            return CommandRunner.execWithResult(repoDir, "git", "symbolic-ref", "--short", "HEAD")
-                    .stream().findFirst().map(String::strip).orElse("main");
-        } catch (CommandExecutionException e) {
-            return "main";
-        }
     }
 
     Result getResult(Config config, DependencyGraph dependencyGraph, List<RepositoryRelease> allReleases) {

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/RepositoryService.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/RepositoryService.java
@@ -23,9 +23,11 @@ import java.util.stream.IntStream;
 @Slf4j
 public class RepositoryService {
     private final GitService gitService;
+    private final String branch;
 
     public RepositoryService(Config config) {
         this.gitService = new GitService(config.getGitConfig());
+        this.branch = config.getBranch();
     }
 
     public List<RepositoryInfo> checkout(String baseDir,
@@ -35,9 +37,12 @@ public class RepositoryService {
         return ParallelExecutor.forEachIn(mergedRepositories)
                 .inParallelOn(4)
                 .execute(rc -> {
-                    Path repository = Paths.get(baseDir, rc.getDir());
-                    gitService.clone(repository, rc);
-                    return new RepositoryInfo(rc, baseDir);
+                    RepositoryConfig effectiveConfig = branch != null
+                            ? RepositoryConfig.builder(rc).branch(branch).build()
+                            : rc;
+                    Path repository = Paths.get(baseDir, effectiveConfig.getDir());
+                    gitService.clone(repository, effectiveConfig);
+                    return new RepositoryInfo(effectiveConfig, baseDir);
                 });
     }
 

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/SemanticReleaseService.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/SemanticReleaseService.java
@@ -57,6 +57,7 @@ public class SemanticReleaseService {
             String[] command = {"semantic-release", "--allow-no-changes", "--no-ci", "--force-bump-patch-version",
                     "--provider", "github",
                     "--provider-opt", "slug=" + repository.getDir(),
+                    "--provider-opt", "github_use_compare_commits=true",
                     "--ci-condition", "default",
                     "--changelog-generator-opt", "format_commit_template=" + CHANGELOG_FORMAT_TEMPLATE};
             CommandRunner.exec(repository.getRepositoryDirFile(), command);

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/model/Config.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/model/Config.java
@@ -27,6 +27,8 @@ public class Config {
     boolean runSequentially;
     boolean skipGoProxy;
     String branch;
+    boolean ltsRelease;
+    String ltsBranchName;
 
     @Builder(builderMethodName = "")
     private Config(String baseDir,
@@ -43,7 +45,9 @@ public class Config {
                    boolean dryRun,
                    boolean runSequentially,
                    boolean skipGoProxy,
-                   String branch) {
+                   String branch,
+                   boolean ltsRelease,
+                   String ltsBranchName) {
         this.baseDir = baseDir;
         this.goProxyDir = goProxyDir;
         this.gitConfig = gitConfig;
@@ -59,6 +63,8 @@ public class Config {
         this.runSequentially = runSequentially;
         this.skipGoProxy = skipGoProxy;
         this.branch = branch;
+        this.ltsRelease = ltsRelease;
+        this.ltsBranchName = ltsBranchName;
     }
 
     public static ConfigBuilder builder(String baseDir,

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/model/Config.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/model/Config.java
@@ -26,6 +26,7 @@ public class Config {
     boolean dryRun;
     boolean runSequentially;
     boolean skipGoProxy;
+    String branch;
 
     @Builder(builderMethodName = "")
     private Config(String baseDir,
@@ -41,7 +42,8 @@ public class Config {
                    boolean skipTests,
                    boolean dryRun,
                    boolean runSequentially,
-                   boolean skipGoProxy) {
+                   boolean skipGoProxy,
+                   String branch) {
         this.baseDir = baseDir;
         this.goProxyDir = goProxyDir;
         this.gitConfig = gitConfig;
@@ -56,6 +58,7 @@ public class Config {
         this.dryRun = dryRun;
         this.runSequentially = runSequentially;
         this.skipGoProxy = skipGoProxy;
+        this.branch = branch;
     }
 
     public static ConfigBuilder builder(String baseDir,

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/model/ReleaseVersion.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/model/ReleaseVersion.java
@@ -18,6 +18,11 @@ public class ReleaseVersion {
         return currentVersion.getMajor() != newVersion.getMajor();
     }
 
+    public boolean isPatchOnlyUpdate() {
+        return currentVersion.getMajor() == newVersion.getMajor()
+                && currentVersion.getMinor() == newVersion.getMinor();
+    }
+
     public int getNewMajorVersion() {
         return newVersion.getMajor();
     }

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/model/Result.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/model/Result.java
@@ -13,4 +13,6 @@ public class Result {
     List<RepositoryRelease> releases;
     Map<Integer, List<RepositoryInfo>> dependencyGraph;
     boolean dryRun;
+    boolean ltsRelease;
+    String ltsBranchName;
 }

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/proxy/GoProxyService.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/proxy/GoProxyService.java
@@ -30,7 +30,7 @@ public class GoProxyService {
                 String[][] commands = {
                         {"go", "env", "-w", goproxy},
                         {"go", "env", "-w", "GONOPROXY="},
-                        {"go", "env", "-w", "GONOSUMDB=*"},
+                        {"go", "env", "-w", "GONOSUMDB=github.com/netcracker/*"},
                         {"go", "env", "-w", "GOPRIVATE="}
                 };
                 for (String[] cmd : commands) {

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/proxy/GoProxyService.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/proxy/GoProxyService.java
@@ -30,7 +30,7 @@ public class GoProxyService {
                 String[][] commands = {
                         {"go", "env", "-w", goproxy},
                         {"go", "env", "-w", "GONOPROXY="},
-                        {"go", "env", "-w", "GONOSUMDB=github.com/netcracker/*"},
+                        {"go", "env", "-w", "GONOSUMDB=*"},
                         {"go", "env", "-w", "GOPRIVATE="}
                 };
                 for (String[] cmd : commands) {

--- a/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/publish/ReleaseSummary.java
+++ b/go-bulk-release/src/main/java/org/qubership/cloud/actions/go/publish/ReleaseSummary.java
@@ -34,10 +34,11 @@ public class ReleaseSummary {
                     return String.format(REPOSITORY_PART_BLOCK, link, gavs);
                 }).toList());
         String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("MM.dd.yyyy HH:mm"));
+        String ltsSummary = result.isLtsRelease() ? buildLtsSummary(result) : "";
         return String.format("""
                 ### Release Summary%s (%s)
-                %s
-                """, result.isDryRun()? " [DRY RUN]" : "", time, releasedRepositoriesGavs);
+                %s%s
+                """, result.isDryRun()? " [DRY RUN]" : "", time, releasedRepositoriesGavs, ltsSummary);
     }
 
     public static String gavs(Result result) {
@@ -46,6 +47,24 @@ public class ReleaseSummary {
 
     public static String dependencyGraphDOT(Result result) {
         return result.getDependenciesDot();
+    }
+
+    private static String buildLtsSummary(Result result) {
+        String rows = result.getReleases().stream()
+                .map(r -> String.format("| %s | %s | %s |",
+                        r.getRepository().getUrl(),
+                        result.getLtsBranchName(),
+                        r.getTag()))
+                .collect(Collectors.joining("\n"));
+        return String.format("""
+
+                ### LTS Steps
+                | Repository | LTS Branch | Created From |
+                |---|---|---|
+                %s
+
+                Technical commits added to the default branch of all repositories listed above.
+                """, rows);
     }
 
     private ReleaseSummary() {}

--- a/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/GoGAVTest.java
+++ b/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/GoGAVTest.java
@@ -1,0 +1,79 @@
+package org.qubership.cloud.actions.go.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GoGAVTest {
+
+    @Test
+    void moduleWithoutVersionSuffix() {
+        GoGAV gav = new GoGAV("github.com/org/repo", "v1.0.0");
+        assertEquals("github.com/org/repo", gav.getArtifactId());
+        assertEquals("github.com/org/repo", gav.getArtifactIdWithoutVersion());
+        assertEquals(1, gav.getMajorVersionFromArtifactId());
+        assertEquals("v1.0.0", gav.getVersion());
+    }
+
+    @Test
+    void moduleWithV2Suffix() {
+        GoGAV gav = new GoGAV("github.com/org/repo/v2", "v2.1.0");
+        assertEquals("github.com/org/repo", gav.getArtifactIdWithoutVersion());
+        assertEquals(2, gav.getMajorVersionFromArtifactId());
+    }
+
+    @Test
+    void moduleWithV10Suffix() {
+        GoGAV gav = new GoGAV("github.com/org/repo/v10", "v10.0.5");
+        assertEquals("github.com/org/repo", gav.getArtifactIdWithoutVersion());
+        assertEquals(10, gav.getMajorVersionFromArtifactId());
+    }
+
+    @Test
+    void isSameArtifactMatchesAcrossMajorVersions() {
+        GoGAV v1 = new GoGAV("github.com/org/repo", "v1.0.0");
+        GoGAV v2 = new GoGAV("github.com/org/repo/v2", "v2.0.0");
+        assertTrue(v1.isSameArtifact(v2));
+        assertTrue(v2.isSameArtifact(v1));
+    }
+
+    @Test
+    void isSameArtifactFalseForDifferentRepos() {
+        GoGAV a = new GoGAV("github.com/org/repo-a", "v1.0.0");
+        GoGAV b = new GoGAV("github.com/org/repo-b", "v1.0.0");
+        assertFalse(a.isSameArtifact(b));
+    }
+
+    @Test
+    void isSameArtifactTrueForSameModuleIdenticalVersion() {
+        GoGAV a = new GoGAV("github.com/org/repo", "v1.2.3");
+        GoGAV b = new GoGAV("github.com/org/repo", "v1.9.0");
+        assertTrue(a.isSameArtifact(b));
+    }
+
+    @Test
+    void toStringFormat() {
+        GoGAV gav = new GoGAV("github.com/org/repo", "v1.0.0");
+        assertEquals("github.com/org/repo:v1.0.0", gav.toString());
+    }
+
+    @Test
+    void updatedVersionStrFormat() {
+        GoGAV gav = new GoGAV("github.com/org/repo", "v1.0.0", "v1.1.0");
+        assertEquals("github.com/org/repo:v1.0.0 -> v1.1.0", gav.getUpdatedVersionStr());
+    }
+
+    @Test
+    void isSameArtifactFalseForNonGoGavWithDifferentArtifactId() {
+        GoGAV goGav = new GoGAV("github.com/org/repo", "v1.0.0");
+        GAV gav = new GAV("GO", "github.com/org/other", "v1.0.0");
+        assertFalse(goGav.isSameArtifact(gav));
+    }
+
+    @Test
+    void isSameArtifactTrueForNonGoGavWithSameGroupAndArtifactId() {
+        GoGAV goGav = new GoGAV("github.com/org/repo", "v1.0.0");
+        GAV gav = new GAV("GO", "github.com/org/repo", "v1.0.0");
+        assertTrue(goGav.isSameArtifact(gav));
+    }
+}

--- a/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/ReleaseVersionTest.java
+++ b/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/ReleaseVersionTest.java
@@ -1,0 +1,47 @@
+package org.qubership.cloud.actions.go.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReleaseVersionTest {
+
+    @Test
+    void majorUpdateDetected() {
+        ReleaseVersion rv = new ReleaseVersion("v1.5.0", "v2.0.0");
+        assertTrue(rv.isMajorUpdate());
+        assertFalse(rv.isPatchOnlyUpdate());
+        assertEquals(2, rv.getNewMajorVersion());
+    }
+
+    @Test
+    void minorUpdateIsNeitherMajorNorPatchOnly() {
+        ReleaseVersion rv = new ReleaseVersion("v1.2.3", "v1.3.0");
+        assertFalse(rv.isMajorUpdate());
+        assertFalse(rv.isPatchOnlyUpdate());
+        assertEquals(1, rv.getNewMajorVersion());
+    }
+
+    @Test
+    void patchUpdateIsPatchOnly() {
+        ReleaseVersion rv = new ReleaseVersion("v1.2.3", "v1.2.4");
+        assertFalse(rv.isMajorUpdate());
+        assertTrue(rv.isPatchOnlyUpdate());
+        assertEquals(1, rv.getNewMajorVersion());
+    }
+
+    @Test
+    void sameVersionIsPatchOnly() {
+        ReleaseVersion rv = new ReleaseVersion("v2.0.0", "v2.0.0");
+        assertFalse(rv.isMajorUpdate());
+        assertTrue(rv.isPatchOnlyUpdate());
+        assertEquals(2, rv.getNewMajorVersion());
+    }
+
+    @Test
+    void highMajorVersionPreserved() {
+        ReleaseVersion rv = new ReleaseVersion("v5.0.0", "v6.0.0");
+        assertTrue(rv.isMajorUpdate());
+        assertEquals(6, rv.getNewMajorVersion());
+    }
+}

--- a/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/SemverTest.java
+++ b/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/SemverTest.java
@@ -1,0 +1,49 @@
+package org.qubership.cloud.actions.go.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SemverTest {
+
+    @Test
+    void parsesValidVersion() {
+        Semver s = new Semver("v1.2.3");
+        assertEquals(1, s.getMajor());
+        assertEquals(2, s.getMinor());
+        assertEquals(3, s.getPatch());
+        assertEquals("v1.2.3", s.getValue());
+        assertEquals("v1.2.3", s.toString());
+    }
+
+    @Test
+    void parsesZeroVersion() {
+        Semver s = new Semver("v0.0.0");
+        assertEquals(0, s.getMajor());
+        assertEquals(0, s.getMinor());
+        assertEquals(0, s.getPatch());
+    }
+
+    @Test
+    void parsesLargeVersion() {
+        Semver s = new Semver("v100.200.300");
+        assertEquals(100, s.getMajor());
+        assertEquals(200, s.getMinor());
+        assertEquals(300, s.getPatch());
+    }
+
+    @Test
+    void rejectsVersionWithoutVPrefix() {
+        assertThrows(IllegalArgumentException.class, () -> new Semver("1.2.3"));
+    }
+
+    @Test
+    void rejectsTwoPartVersion() {
+        assertThrows(IllegalArgumentException.class, () -> new Semver("v1.2"));
+    }
+
+    @Test
+    void rejectsNonNumericVersion() {
+        assertThrows(IllegalArgumentException.class, () -> new Semver("invalid"));
+    }
+}

--- a/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/gomod/GoModuleFactoryTest.java
+++ b/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/gomod/GoModuleFactoryTest.java
@@ -1,0 +1,176 @@
+package org.qubership.cloud.actions.go.model.gomod;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.qubership.cloud.actions.go.model.GoGAV;
+import org.qubership.cloud.actions.go.model.UnexpectedException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GoModuleFactoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void parsesModuleNameAndRequireBlock() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, """
+                module github.com/org/repo
+
+                go 1.21
+
+                require (
+                    github.com/dep/one v1.2.3
+                    github.com/dep/two v0.5.0
+                )
+                """);
+
+        GoModule module = GoModuleFactory.create(tempDir, goMod);
+
+        assertEquals("github.com/org/repo", module.moduleName());
+        assertEquals("", module.relativePath());
+        assertFalse(module.isSubModule());
+        assertEquals(2, module.dependencies().size());
+        assertTrue(module.dependencies().stream()
+                .anyMatch(d -> d.getArtifactId().equals("github.com/dep/one") && d.getVersion().equals("v1.2.3")));
+        assertTrue(module.dependencies().stream()
+                .anyMatch(d -> d.getArtifactId().equals("github.com/dep/two") && d.getVersion().equals("v0.5.0")));
+    }
+
+    @Test
+    void parsesSingleLineRequire() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, """
+                module github.com/org/repo
+
+                require github.com/dep/single v3.1.0
+                """);
+
+        GoModule module = GoModuleFactory.create(tempDir, goMod);
+
+        assertEquals(1, module.dependencies().size());
+        GoGAV dep = module.dependencies().iterator().next();
+        assertEquals("github.com/dep/single", dep.getArtifactId());
+        assertEquals("v3.1.0", dep.getVersion());
+    }
+
+    @Test
+    void stripsInlineCommentFromDependency() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, """
+                module github.com/org/repo
+
+                require (
+                    github.com/dep/lib v2.0.0 // indirect
+                )
+                """);
+
+        GoModule module = GoModuleFactory.create(tempDir, goMod);
+
+        assertEquals(1, module.dependencies().size());
+        GoGAV dep = module.dependencies().iterator().next();
+        assertEquals("github.com/dep/lib", dep.getArtifactId());
+        assertEquals("v2.0.0", dep.getVersion());
+    }
+
+    @Test
+    void skipsCommentLines() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, """
+                module github.com/org/repo
+
+                // this is a top-level comment
+                require (
+                    // another comment inside block
+                    github.com/dep/lib v1.0.0
+                )
+                """);
+
+        GoModule module = GoModuleFactory.create(tempDir, goMod);
+
+        assertEquals(1, module.dependencies().size());
+    }
+
+    @Test
+    void parsesSubmoduleRelativePath() throws IOException {
+        Path subDir = tempDir.resolve("submodule");
+        Files.createDirectories(subDir);
+        Path goMod = subDir.resolve("go.mod");
+        Files.writeString(goMod, "module github.com/org/repo/submodule\n");
+
+        GoModule module = GoModuleFactory.create(tempDir, goMod);
+
+        assertEquals("submodule", module.relativePath());
+        assertTrue(module.isSubModule());
+    }
+
+    @Test
+    void throwsWhenModuleNameMissing() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, """
+                go 1.21
+
+                require (
+                    github.com/dep/lib v1.0.0
+                )
+                """);
+
+        assertThrows(UnexpectedException.class, () -> GoModuleFactory.create(tempDir, goMod));
+    }
+
+    @Test
+    void parsesModuleWithNoDependencies() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, "module github.com/org/repo\n");
+
+        GoModule module = GoModuleFactory.create(tempDir, goMod);
+
+        assertEquals("github.com/org/repo", module.moduleName());
+        assertTrue(module.dependencies().isEmpty());
+    }
+
+    @Test
+    void parsesMultipleSingleLineRequires() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, """
+                module github.com/org/repo
+
+                require github.com/dep/a v1.0.0
+                require github.com/dep/b v2.0.0
+                """);
+
+        GoModule module = GoModuleFactory.create(tempDir, goMod);
+
+        assertEquals(2, module.dependencies().size());
+    }
+
+    @Test
+    void throwsOnDependencyLineWithNoVersion() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, """
+                module github.com/org/repo
+
+                require (
+                    github.com/dep/no-version
+                )
+                """);
+
+        assertThrows(UnexpectedException.class, () -> GoModuleFactory.create(tempDir, goMod));
+    }
+
+    @Test
+    void unclosedRequireBlockParsesSubsequentLinesAsGhostDependencies() throws IOException {
+        Path goMod = tempDir.resolve("go.mod");
+        Files.writeString(goMod, "module github.com/org/repo\n\nrequire (\n    github.com/dep/lib v1.0.0\n\ngo 1.21\n");
+
+        GoModule module = GoModuleFactory.create(tempDir, goMod);
+
+        assertTrue(module.dependencies().stream().anyMatch(d -> d.getArtifactId().equals("go")),
+                "unclosed require block leaks subsequent lines as ghost dependencies");
+    }
+}

--- a/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/graph/RepositoryInfoLinkerTest.java
+++ b/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/graph/RepositoryInfoLinkerTest.java
@@ -1,0 +1,110 @@
+package org.qubership.cloud.actions.go.model.graph;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.qubership.cloud.actions.go.model.repository.RepositoryConfig;
+import org.qubership.cloud.actions.go.model.repository.RepositoryInfo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RepositoryInfoLinkerTest {
+
+    private static RepositoryInfo createRepo(Path baseDir, String orgAndName, String module, String... requires) throws IOException {
+        Path repoDir = baseDir.resolve(orgAndName);
+        Files.createDirectories(repoDir);
+        StringBuilder goMod = new StringBuilder("module ").append(module).append("\n");
+        if (requires.length > 0) {
+            goMod.append("\nrequire (\n");
+            for (String req : requires) {
+                goMod.append("    ").append(req).append("\n");
+            }
+            goMod.append(")\n");
+        }
+        Files.writeString(repoDir.resolve("go.mod"), goMod.toString());
+        RepositoryConfig config = RepositoryConfig.fromConfig("https://host/" + orgAndName);
+        return new RepositoryInfo(config, baseDir.toString());
+    }
+
+    @Test
+    void reposThatDependOnEachOther(@TempDir Path tempDir) throws IOException {
+        RepositoryInfo repoA = createRepo(tempDir, "org/repo-a", "github.com/org/repo-a");
+        RepositoryInfo repoB = createRepo(tempDir, "org/repo-b", "github.com/org/repo-b",
+                "github.com/org/repo-a v1.0.0");
+
+        RepositoryInfoLinker linker = new RepositoryInfoLinker(List.of(repoA, repoB));
+
+        List<RepositoryInfo> usedByB = linker.getRepositoriesUsedByThis(repoB);
+        assertEquals(1, usedByB.size());
+        assertSame(repoA, usedByB.get(0));
+    }
+
+    @Test
+    void repoWithNoDepsReturnsEmptyList(@TempDir Path tempDir) throws IOException {
+        RepositoryInfo repoA = createRepo(tempDir, "org/repo-a", "github.com/org/repo-a");
+        RepositoryInfo repoB = createRepo(tempDir, "org/repo-b", "github.com/org/repo-b",
+                "github.com/org/repo-a v1.0.0");
+
+        RepositoryInfoLinker linker = new RepositoryInfoLinker(List.of(repoA, repoB));
+
+        List<RepositoryInfo> usedByA = linker.getRepositoriesUsedByThis(repoA);
+        assertTrue(usedByA.isEmpty());
+    }
+
+    @Test
+    void getRepositoriesUsingThis(@TempDir Path tempDir) throws IOException {
+        RepositoryInfo repoA = createRepo(tempDir, "org/repo-a", "github.com/org/repo-a");
+        RepositoryInfo repoB = createRepo(tempDir, "org/repo-b", "github.com/org/repo-b",
+                "github.com/org/repo-a v1.0.0");
+
+        RepositoryInfoLinker linker = new RepositoryInfoLinker(List.of(repoA, repoB));
+
+        List<RepositoryInfo> usingA = linker.getRepositoriesUsingThis(repoA);
+        assertEquals(1, usingA.size());
+        assertSame(repoB, usingA.get(0));
+    }
+
+    @Test
+    void matchesMajorVersionSuffixInDependency(@TempDir Path tempDir) throws IOException {
+        RepositoryInfo repoA = createRepo(tempDir, "org/repo-a", "github.com/org/repo-a");
+        RepositoryInfo repoC = createRepo(tempDir, "org/repo-c", "github.com/org/repo-c",
+                "github.com/org/repo-a/v2 v2.0.0");
+
+        RepositoryInfoLinker linker = new RepositoryInfoLinker(List.of(repoA, repoC));
+
+        List<RepositoryInfo> usedByC = linker.getRepositoriesUsedByThis(repoC);
+        assertEquals(1, usedByC.size());
+        assertSame(repoA, usedByC.get(0));
+    }
+
+    @Test
+    void transitiveDependenciesIncludedInFlatSet(@TempDir Path tempDir) throws IOException {
+        RepositoryInfo repoA = createRepo(tempDir, "org/repo-a", "github.com/org/repo-a");
+        RepositoryInfo repoB = createRepo(tempDir, "org/repo-b", "github.com/org/repo-b",
+                "github.com/org/repo-a v1.0.0");
+        RepositoryInfo repoC = createRepo(tempDir, "org/repo-c", "github.com/org/repo-c",
+                "github.com/org/repo-b v1.0.0");
+
+        RepositoryInfoLinker linker = new RepositoryInfoLinker(List.of(repoA, repoB, repoC));
+
+        Set<RepositoryInfo> flatSet = linker.getRepositoriesUsedByThisFlatSet(repoC);
+        assertEquals(2, flatSet.size());
+        assertTrue(flatSet.stream().anyMatch(r -> r.getUrl().equals(repoA.getUrl())));
+        assertTrue(flatSet.stream().anyMatch(r -> r.getUrl().equals(repoB.getUrl())));
+    }
+
+    @Test
+    void noSelfReferenceReturned(@TempDir Path tempDir) throws IOException {
+        RepositoryInfo repoA = createRepo(tempDir, "org/repo-a", "github.com/org/repo-a");
+
+        RepositoryInfoLinker linker = new RepositoryInfoLinker(List.of(repoA));
+
+        assertTrue(linker.getRepositoriesUsedByThis(repoA).isEmpty());
+        assertTrue(linker.getRepositoriesUsingThis(repoA).isEmpty());
+    }
+}

--- a/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/repository/RepositoryConfigTest.java
+++ b/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/model/repository/RepositoryConfigTest.java
@@ -1,0 +1,82 @@
+package org.qubership.cloud.actions.go.model.repository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RepositoryConfigTest {
+
+    @Test
+    void parsesUrlWithoutParams() {
+        RepositoryConfig config = RepositoryConfig.fromConfig("https://github.com/org/repo");
+        assertEquals("https://github.com/org/repo", config.getUrl());
+        assertEquals("org/repo", config.getDir());
+        assertEquals("HEAD", config.getBranch());
+        assertNull(config.getVersion());
+        assertFalse(config.isSkipTests());
+    }
+
+    @Test
+    void parsesUrlWithBranchParam() {
+        RepositoryConfig config = RepositoryConfig.fromConfig("https://github.com/org/repo[branch=main]");
+        assertEquals("main", config.getBranch());
+    }
+
+    @Test
+    void parsesUrlWithFromAlias() {
+        RepositoryConfig config = RepositoryConfig.fromConfig("https://github.com/org/repo[from=develop]");
+        assertEquals("develop", config.getBranch());
+    }
+
+    @Test
+    void parsesUrlWithVersionParam() {
+        RepositoryConfig config = RepositoryConfig.fromConfig("https://github.com/org/repo[version=v2.0.0]");
+        assertEquals("v2.0.0", config.getVersion());
+    }
+
+    @Test
+    void parsesUrlWithSkipTestsParam() {
+        RepositoryConfig config = RepositoryConfig.fromConfig("https://github.com/org/repo[skipTests=true]");
+        assertTrue(config.isSkipTests());
+    }
+
+    @Test
+    void parsesUrlWithAllParams() {
+        RepositoryConfig config = RepositoryConfig.fromConfig(
+                "https://github.com/org/repo[branch=feature,version=v1.5.0,skipTests=true]");
+        assertEquals("feature", config.getBranch());
+        assertEquals("v1.5.0", config.getVersion());
+        assertTrue(config.isSkipTests());
+    }
+
+    @Test
+    void normalizesGitSuffix() {
+        RepositoryConfig config = RepositoryConfig.fromConfig("https://github.com/org/repo.git");
+        assertEquals("https://github.com/org/repo", config.getUrl());
+    }
+
+    @Test
+    void defaultBranchIsHeadWhenNotSpecified() {
+        RepositoryConfig config = RepositoryConfig.fromConfig("https://github.com/org/repo[version=v1.0.0]");
+        assertEquals("HEAD", config.getBranch());
+    }
+
+    @Test
+    void throwsOnInvalidUrl() {
+        assertThrows(IllegalArgumentException.class, () -> RepositoryConfig.fromConfig("not-a-url"));
+    }
+
+    @Test
+    void branchParamTakesPriorityOverFromAlias() {
+        RepositoryConfig config = RepositoryConfig.fromConfig(
+                "https://github.com/org/repo[branch=main,from=develop]");
+        assertEquals("main", config.getBranch());
+    }
+
+    @Test
+    void paramValueWithEmbeddedEqualSignIsDropped() {
+        RepositoryConfig config = RepositoryConfig.fromConfig(
+                "https://github.com/org/repo[version=v1.0.0=extra]");
+        assertNull(config.getVersion());
+    }
+}

--- a/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/publish/ReleaseSummaryTest.java
+++ b/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/publish/ReleaseSummaryTest.java
@@ -1,0 +1,163 @@
+package org.qubership.cloud.actions.go.publish;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.qubership.cloud.actions.go.model.GoGAV;
+import org.qubership.cloud.actions.go.model.Result;
+import org.qubership.cloud.actions.go.model.repository.RepositoryConfig;
+import org.qubership.cloud.actions.go.model.repository.RepositoryInfo;
+import org.qubership.cloud.actions.go.model.repository.RepositoryRelease;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReleaseSummaryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private RepositoryRelease createRelease(String orgAndName, String branch, String tag, boolean pushedToGit) throws IOException {
+        Path repoDir = tempDir.resolve(orgAndName);
+        Files.createDirectories(repoDir);
+        Files.writeString(repoDir.resolve("go.mod"), "module github.com/" + orgAndName + "\n");
+        String configUrl = branch.equals("HEAD")
+                ? "https://host/" + orgAndName
+                : "https://host/" + orgAndName + "[branch=" + branch + "]";
+        RepositoryConfig config = RepositoryConfig.fromConfig(configUrl);
+        RepositoryInfo repoInfo = new RepositoryInfo(config, tempDir.toString());
+
+        RepositoryRelease release = new RepositoryRelease();
+        release.setRepository(repoInfo);
+        release.setTag(tag);
+        release.setPushedToGit(pushedToGit);
+        release.setGavs(List.of(new GoGAV("github.com/" + orgAndName, "v0.9.0", "v1.0.0")));
+        return release;
+    }
+
+    // --- gavs() ---
+
+    @Test
+    void gavsJoinsAllGavsWithComma() {
+        RepositoryRelease r1 = new RepositoryRelease();
+        r1.setGavs(List.of(new GoGAV("github.com/org/repo-a", "v1.0.0")));
+        RepositoryRelease r2 = new RepositoryRelease();
+        r2.setGavs(List.of(new GoGAV("github.com/org/repo-b", "v2.1.3")));
+
+        Result result = new Result();
+        result.setReleases(List.of(r1, r2));
+
+        assertEquals("github.com/org/repo-a:v1.0.0,github.com/org/repo-b:v2.1.3", ReleaseSummary.gavs(result));
+    }
+
+    @Test
+    void gavsHandlesMultipleGavsPerRelease() {
+        RepositoryRelease r = new RepositoryRelease();
+        r.setGavs(List.of(
+                new GoGAV("github.com/org/mod-a", "v3.0.0"),
+                new GoGAV("github.com/org/mod-b/v2", "v2.5.0")
+        ));
+
+        Result result = new Result();
+        result.setReleases(List.of(r));
+
+        String gavs = ReleaseSummary.gavs(result);
+        assertTrue(gavs.contains("github.com/org/mod-a:v3.0.0"));
+        assertTrue(gavs.contains("github.com/org/mod-b/v2:v2.5.0"));
+    }
+
+    @Test
+    void gavsReturnsEmptyStringForNoReleases() {
+        Result result = new Result();
+        result.setReleases(List.of());
+
+        assertEquals("", ReleaseSummary.gavs(result));
+    }
+
+    // --- md() ---
+
+    @Test
+    void mdContainsDryRunAnnotation() throws IOException {
+        RepositoryRelease release = createRelease("org/repo", "HEAD", "v1.0.0", false);
+        Result result = new Result();
+        result.setReleases(List.of(release));
+        result.setDryRun(true);
+
+        assertTrue(ReleaseSummary.md(result).contains("[DRY RUN]"));
+    }
+
+    @Test
+    void mdOmitsDryRunAnnotationWhenNotDryRun() throws IOException {
+        RepositoryRelease release = createRelease("org/repo", "HEAD", "v1.0.0", false);
+        Result result = new Result();
+        result.setReleases(List.of(release));
+        result.setDryRun(false);
+
+        assertFalse(ReleaseSummary.md(result).contains("[DRY RUN]"));
+    }
+
+    @Test
+    void mdUsesTagUrlWhenPushedToGit() throws IOException {
+        RepositoryRelease release = createRelease("org/repo", "HEAD", "v1.2.3", true);
+        Result result = new Result();
+        result.setReleases(List.of(release));
+
+        String md = ReleaseSummary.md(result);
+        assertTrue(md.contains("https://host/org/repo/releases/tag/v1.2.3"));
+    }
+
+    @Test
+    void mdUsesRepoUrlWhenNotPushedToGit() throws IOException {
+        RepositoryRelease release = createRelease("org/repo", "HEAD", "v1.2.3", false);
+        Result result = new Result();
+        result.setReleases(List.of(release));
+
+        String md = ReleaseSummary.md(result);
+        assertFalse(md.contains("/releases/tag/"));
+        assertTrue(md.contains("https://host/org/repo"));
+    }
+
+    @Test
+    void mdIncludesBranchNameWhenNotHead() throws IOException {
+        RepositoryRelease release = createRelease("org/repo", "lts/25.1", "v1.0.0", false);
+        Result result = new Result();
+        result.setReleases(List.of(release));
+
+        assertTrue(ReleaseSummary.md(result).contains("[lts/25.1]"));
+    }
+
+    @Test
+    void mdOmitsBranchNameForHeadBranch() throws IOException {
+        RepositoryRelease release = createRelease("org/repo", "HEAD", "v1.0.0", false);
+        Result result = new Result();
+        result.setReleases(List.of(release));
+
+        assertFalse(ReleaseSummary.md(result).contains("[HEAD]"));
+    }
+
+    @Test
+    void mdIncludesLtsSummaryWhenLtsRelease() throws IOException {
+        RepositoryRelease release = createRelease("org/repo", "HEAD", "v1.0.0", true);
+        Result result = new Result();
+        result.setReleases(List.of(release));
+        result.setLtsRelease(true);
+        result.setLtsBranchName("lts/25.2");
+
+        String md = ReleaseSummary.md(result);
+        assertTrue(md.contains("### LTS Steps"));
+        assertTrue(md.contains("lts/25.2"));
+    }
+
+    @Test
+    void mdOmitsLtsSummaryWhenNotLtsRelease() throws IOException {
+        RepositoryRelease release = createRelease("org/repo", "HEAD", "v1.0.0", true);
+        Result result = new Result();
+        result.setReleases(List.of(release));
+        result.setLtsRelease(false);
+
+        assertFalse(ReleaseSummary.md(result).contains("### LTS Steps"));
+    }
+}

--- a/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/util/UrlUtilsTest.java
+++ b/go-bulk-release/src/test/java/org/qubership/cloud/actions/go/util/UrlUtilsTest.java
@@ -1,0 +1,33 @@
+package org.qubership.cloud.actions.go.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UrlUtilsTest {
+
+    @Test
+    void extractsDirFromSimpleUrl() {
+        assertEquals("org/repo", UrlUtils.getDirName("https://github.com/org/repo"));
+    }
+
+    @Test
+    void extractsDirFromUrlWithParams() {
+        assertEquals("org/repo", UrlUtils.getDirName("https://github.com/org/repo[branch=main]"));
+    }
+
+    @Test
+    void extractsDirFromUrlWithMultiplePathSegments() {
+        assertEquals("org/sub/repo", UrlUtils.getDirName("https://github.com/org/sub/repo"));
+    }
+
+    @Test
+    void throwsOnInvalidUrl() {
+        assertThrows(IllegalArgumentException.class, () -> UrlUtils.getDirName("not-a-url"));
+    }
+
+    @Test
+    void throwsOnRelativeUrl() {
+        assertThrows(IllegalArgumentException.class, () -> UrlUtils.getDirName("org/repo"));
+    }
+}


### PR DESCRIPTION
## Why

The Go bulk-release tool could only release from the default branch and had no
support for long-term-support (LTS) lines. It also pushed to remotes without
checking whether the push was accepted, so a rejected push could pass silently.

## What

- **Branch release mode** (`--branch`): check out every repository from a given
  branch and release from it. Only patch-level bumps are allowed — a `feat:` or
  `BREAKING CHANGE` commit on the branch aborts the release with a clear error.
- **LTS release mode** (`--ltsRelease`, `--ltsBranchName`): after a normal
  release, create and push an LTS branch (validated against `lts/YY.N`, e.g.
  `lts/26.2`) for each repository, then add an empty technical `feat:` commit to
  the default branch to open the next minor line. Mutually exclusive with
  `--branch` and `--repositoriesToReleaseFrom`. The release summary gains an
  "LTS Steps" section.
- **Push verification**: `pushChanges` and the new `pushBranch` inspect every
  `RemoteRefUpdate` and fail loudly when the remote rejects a push or reports no
  ref updates.
- **Changelog accuracy**: pass `github_use_compare_commits=true` to
  semantic-release to fix an oversized commit delta between releases.
- **Tests**: add JUnit 5 unit tests for the model, gomod, graph, repository, and
  publish packages (`GoGAV`, `ReleaseVersion`, `Semver`, `GoModuleFactory`,
  `RepositoryInfoLinker`, `RepositoryConfig`, `ReleaseSummary`, `UrlUtils`).

## How to verify

- Branch release: run the CLI with `--branch <name> --dryRun` and confirm a
  non-patch bump is rejected.
- LTS release against a test org: run with `--ltsRelease --ltsBranchName lts/26.2`
  and confirm LTS branches are pushed and the technical commit lands on the
  default branch.