### PR TITLE
ci: add manual workflow to run the SNAPSHOT inter-module e2e test

### DIFF
--- a/.github/workflows/e2e-switch-inter-module-deps.yml
+++ b/.github/workflows/e2e-switch-inter-module-deps.yml
@@ -1,0 +1,34 @@
+# E2E: switch inter-module deps to SNAPSHOT
+#
+# Runs the heavy, gated end-to-end test SwitchInterModuleDepsToSnapshotE2ETest, which spawns a real
+# `mvn release:prepare` on a throwaway mini-monorepo and then exercises the SNAPSHOT rewrite pass.
+# It is excluded from the regular build (guarded by -De2e=true) because it launches real mvn
+# subprocesses; run it here on Linux where `mvn` is directly executable.
+#
+# Trigger: manual (workflow_dispatch).
+
+name: E2E switch inter-module deps to SNAPSHOT
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: release:prepare + SNAPSHOT pass
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Run gated e2e test
+        run: >
+          mvn -B -ntp -f maven-bulk-release/pom.xml test
+          -De2e=true
+          -Dtest=SwitchInterModuleDepsToSnapshotE2ETest


### PR DESCRIPTION
Adds a workflow_dispatch workflow so the gated e2e test (SwitchInterModuleDepsToSnapshotE2ETest, run with -De2e=true) can be launched on Linux. The test class itself lands with the feature branch; dispatch this workflow selecting that branch as the ref.