### PR TITLE
feat: snapshot inter module deps

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,34 @@
+# E2E tests
+#
+# Runs all heavy, gated end-to-end tests (class name *E2ETest) that are excluded from the regular
+# build. They are guarded by -De2e=true because they spawn real `mvn` subprocesses; run them here on
+# Linux where `mvn` is directly executable.
+#
+# Trigger: manual (workflow_dispatch).
+
+name: E2E tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: Run all e2e tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Run gated e2e tests
+        run: >
+          mvn -B -ntp -f maven-bulk-release/pom.xml test
+          -De2e=true
+          -Dtest='*E2ETest'
+          -DfailIfNoTests=false

--- a/maven-bulk-release-cli/src/main/java/org/qubership/cloud/actions/maven/MavenBulkReleaseCli.java
+++ b/maven-bulk-release-cli/src/main/java/org/qubership/cloud/actions/maven/MavenBulkReleaseCli.java
@@ -75,6 +75,10 @@ public class MavenBulkReleaseCli implements Runnable {
             """)
     private boolean dryRun;
 
+    @CommandLine.Option(names = {"--switchInterModuleDepsToSnapshot"}, arity = "0", defaultValue = "false",
+            description = "after a full release from main, rewrite all inter-module dependencies in main back to the current SNAPSHOT versions so trunk keeps developing against SNAPSHOTs")
+    private boolean switchInterModuleDepsToSnapshot;
+
     @CommandLine.Option(names = {"--mavenAltDeploymentRepository"},
             description = "altDeploymentRepository to pass to release:perform mvn command to override deploymentRepository to deploy artifacts to")
     private String mavenAltDeploymentRepository;
@@ -159,6 +163,7 @@ public class MavenBulkReleaseCli implements Runnable {
                     .gavs(gavs)
                     .skipTests(skipTests)
                     .dryRun(dryRun)
+                    .switchInterModuleDepsToSnapshot(switchInterModuleDepsToSnapshot)
                     .runParallelism(runParallelism)
                     .logsToConsole(logsToConsole)
                     .build();

--- a/maven-bulk-release/src/main/java/org/qubership/cloud/actions/maven/ReleaseRunner.java
+++ b/maven-bulk-release/src/main/java/org/qubership/cloud/actions/maven/ReleaseRunner.java
@@ -40,6 +40,7 @@ public class ReleaseRunner {
 
     public Result release(Config config) throws Exception {
         Result result = new Result();
+        assertPartialReleaseAllowed(config);
         log.info("Config: {}", yamlMapper.writeValueAsString(config));
         // set up git creds if necessary
         GitService gitService = new GitService(config.getGitConfig());
@@ -158,6 +159,7 @@ public class ReleaseRunner {
         }).toList();
 
         if (!config.isDryRun()) {
+            switchInterModuleDepsToSnapshot(config, allReleases);
             Map<Integer, Map<String, List<RepositoryInfo>>> publishDependencyGraph = new TreeMap<>();
             AtomicInteger newLevel = new AtomicInteger(-1);
             AtomicReference<String> lastUrlRef = new AtomicReference<>();
@@ -240,6 +242,48 @@ public class ReleaseRunner {
         return result;
     }
 
+    static final String MAIN_BRANCH = "main";
+
+    static String resolveReleaseBranch(Config config) {
+        return config.getRepositories().stream()
+                .filter(Objects::nonNull)
+                .map(RepositoryConfig::getBranch)
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
+    }
+
+    boolean shouldSwitchInterModuleDepsToSnapshot(Config config, String branch) {
+        return config.isSwitchInterModuleDepsToSnapshot()
+               && MAIN_BRANCH.equals(branch)
+               && !config.isDryRun();
+    }
+
+    void switchInterModuleDepsToSnapshot(Config config, List<RepositoryRelease> allReleases) {
+        if (!shouldSwitchInterModuleDepsToSnapshot(config, resolveReleaseBranch(config))) {
+            return;
+        }
+        Set<GAV> snapshotGavs = allReleases.stream()
+                .flatMap(r -> r.getDevGavs().stream())
+                .collect(Collectors.toSet());
+        Map<String, List<RepositoryInfo>> reposByUrl = allReleases.stream()
+                .map(RepositoryRelease::getRepository)
+                .collect(Collectors.groupingBy(RepositoryInfo::getUrl, LinkedHashMap::new, Collectors.toList()));
+        reposByUrl.forEach((url, repos) -> {
+            repos.forEach(ri -> ri.updateDepVersions(snapshotGavs));
+            commitUpdatedDependenciesIfAny(repos.getFirst(), "switch inter-module deps to SNAPSHOT after release");
+        });
+    }
+
+    void assertPartialReleaseAllowed(Config config) {
+        boolean partial = !config.getRepositoriesToReleaseFrom().isEmpty();
+        if (config.isSwitchInterModuleDepsToSnapshot()
+            && MAIN_BRANCH.equals(resolveReleaseBranch(config))
+            && partial) {
+            throw new IllegalStateException(
+                    "partial release is not allowed from main, only from LTS branch");
+        }
+    }
+
     RepositoryRelease releasePrepare(Config config, RepositoryInfo repository, Collection<GAV> dependencies, OutputStream outputStream) throws Exception {
         try (outputStream) {
             updateDependencies(repository, dependencies);
@@ -287,15 +331,18 @@ public class ReleaseRunner {
     }
 
     synchronized void commitUpdatedDependenciesIfAny(RepositoryInfo repository) {
+        commitUpdatedDependenciesIfAny(repository, "updating dependencies before release");
+    }
+
+    synchronized void commitUpdatedDependenciesIfAny(RepositoryInfo repository, String message) {
         Path repositoryDirPath = Paths.get(repository.getBaseDir(), repository.getDir());
         try (Git git = Git.open(repositoryDirPath.toFile())) {
             List<DiffEntry> diff = git.diff().call();
             List<String> modifiedFiles = diff.stream().filter(d -> d.getChangeType() == DiffEntry.ChangeType.MODIFY).map(DiffEntry::getNewPath).toList();
             if (!modifiedFiles.isEmpty()) {
                 git.add().setUpdate(true).call();
-                String msg = "updating dependencies before release";
-                git.commit().setMessage(msg).call();
-                log.info("Commited '{}', changed files:\n{}", msg, String.join("\n", modifiedFiles));
+                git.commit().setMessage(message).call();
+                log.info("Commited '{}', changed files:\n{}", message, String.join("\n", modifiedFiles));
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -341,9 +388,16 @@ public class ReleaseRunner {
             if (process.exitValue() != 0) {
                 throw new RuntimeException("Failed to execute cmd");
             }
-            List<GAV> gavs = Files.readString(Paths.get(repositoryDirPath.toString(), "release.properties")).lines()
+            List<String> releasePropertiesLines = Files.readString(Paths.get(repositoryDirPath.toString(), "release.properties")).lines().toList();
+            List<GAV> gavs = releasePropertiesLines.stream()
                     .filter(l -> l.startsWith("project.rel."))
                     .map(l -> l.replace("project.rel.", "")
+                            .replace("\\", "")
+                            .replace("=", ":"))
+                    .map(GAV::new).toList();
+            List<GAV> devGavs = releasePropertiesLines.stream()
+                    .filter(l -> l.startsWith("project.dev."))
+                    .map(l -> l.replace("project.dev.", "")
                             .replace("\\", "")
                             .replace("=", ":"))
                     .map(GAV::new).toList();
@@ -352,6 +406,7 @@ public class ReleaseRunner {
             release.setVersionTag(versionTag);
             release.setJavaVersion(javaVersion);
             release.setGavs(gavs);
+            release.setDevGavs(devGavs);
             return release;
         } finally {
             printWriter.flush();

--- a/maven-bulk-release/src/main/java/org/qubership/cloud/actions/maven/model/Config.java
+++ b/maven-bulk-release/src/main/java/org/qubership/cloud/actions/maven/model/Config.java
@@ -23,6 +23,7 @@ public class Config {
     Map<String, String> javaVersionToJavaHomeEnv;
     boolean skipTests;
     boolean dryRun;
+    boolean switchInterModuleDepsToSnapshot;
     boolean logsToConsole;
     int runParallelism;
     @JsonIgnore
@@ -39,6 +40,7 @@ public class Config {
                    MavenConfig mavenConfig,
                    boolean skipTests,
                    boolean dryRun,
+                   boolean switchInterModuleDepsToSnapshot,
                    boolean logsToConsole,
                    int runParallelism,
                    OutputStream summaryOutputStream) {
@@ -51,6 +53,7 @@ public class Config {
         this.repositoriesToReleaseFrom = repositoriesToReleaseFrom;
         this.skipTests = skipTests;
         this.dryRun = dryRun;
+        this.switchInterModuleDepsToSnapshot = switchInterModuleDepsToSnapshot;
         this.logsToConsole = logsToConsole;
         this.runParallelism = runParallelism <= 0 ? 1 : runParallelism;
         this.versionIncrementType = versionIncrementType;

--- a/maven-bulk-release/src/main/java/org/qubership/cloud/actions/maven/model/PomHolder.java
+++ b/maven-bulk-release/src/main/java/org/qubership/cloud/actions/maven/model/PomHolder.java
@@ -248,8 +248,15 @@ public class PomHolder {
 
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    List<String> pathList = Arrays.asList(file.toString().split("/"));
-                    if (pathList.contains("pom.xml") && !pathList.contains("target")) {
+                    boolean isPom = file.getFileName() != null && "pom.xml".equals(file.getFileName().toString());
+                    boolean underTarget = false;
+                    for (Path part : file) {
+                        if ("target".equals(part.toString())) {
+                            underTarget = true;
+                            break;
+                        }
+                    }
+                    if (isPom && !underTarget) {
                         poms.add(parsePom(file));
                     }
                     return FileVisitResult.CONTINUE;

--- a/maven-bulk-release/src/main/java/org/qubership/cloud/actions/maven/model/RepositoryRelease.java
+++ b/maven-bulk-release/src/main/java/org/qubership/cloud/actions/maven/model/RepositoryRelease.java
@@ -9,6 +9,7 @@ public class RepositoryRelease {
     RepositoryInfo repository;
     VersionTag versionTag;
     List<GAV> gavs;
+    List<GAV> devGavs;
     String javaVersion;
     boolean pushedToGit;
     boolean deployed;

--- a/maven-bulk-release/src/test/java/org/qubership/cloud/actions/maven/ReleaseRunnerSnapshotTest.java
+++ b/maven-bulk-release/src/test/java/org/qubership/cloud/actions/maven/ReleaseRunnerSnapshotTest.java
@@ -1,0 +1,55 @@
+package org.qubership.cloud.actions.maven;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.qubership.cloud.actions.maven.model.Config;
+import org.qubership.cloud.actions.maven.model.GitConfig;
+import org.qubership.cloud.actions.maven.model.MavenConfig;
+import org.qubership.cloud.actions.maven.model.RepositoryConfig;
+
+import java.util.List;
+
+public class ReleaseRunnerSnapshotTest {
+
+    static Config config(String branch, boolean flag, boolean dryRun, boolean partial) {
+        RepositoryConfig repo = RepositoryConfig.builder("https://github.com/test/mono").branch(branch).build();
+        Config.ConfigBuilder builder = Config.builder("/tmp",
+                        GitConfig.builder().url("https://github.com").username("u").email("e").password("p").build(),
+                        MavenConfig.builder().build(),
+                        List.of(repo))
+                .dryRun(dryRun)
+                .switchInterModuleDepsToSnapshot(flag);
+        if (partial) {
+            builder.repositoriesToReleaseFrom(java.util.Set.of(repo));
+        }
+        return builder.build();
+    }
+
+    @Test
+    void gateOnlyWhenFlagMainAndNotDryRun() {
+        ReleaseRunner runner = new ReleaseRunner();
+        Assertions.assertTrue(runner.shouldSwitchInterModuleDepsToSnapshot(config("main", true, false, false), "main"));
+        Assertions.assertFalse(runner.shouldSwitchInterModuleDepsToSnapshot(config("main", false, false, false), "main"));
+        Assertions.assertFalse(runner.shouldSwitchInterModuleDepsToSnapshot(config("main", true, true, false), "main"));
+        Assertions.assertFalse(runner.shouldSwitchInterModuleDepsToSnapshot(config("lts/1.2.3", true, false, false), "lts/1.2.3"));
+    }
+
+    @Test
+    void guardBlocksPartialReleaseFromMainWithFlag() {
+        ReleaseRunner runner = new ReleaseRunner();
+        IllegalStateException ex = Assertions.assertThrows(IllegalStateException.class,
+                () -> runner.assertPartialReleaseAllowed(config("main", true, false, true)));
+        Assertions.assertTrue(ex.getMessage().contains("partial release is not allowed from main"));
+    }
+
+    @Test
+    void guardAllowsPartialReleaseWhenServiceCaseOrBranch() {
+        ReleaseRunner runner = new ReleaseRunner();
+        // services / any run without the flag: partial from main stays allowed
+        Assertions.assertDoesNotThrow(() -> runner.assertPartialReleaseAllowed(config("main", false, false, true)));
+        // partial from a non-main branch is allowed even with the flag
+        Assertions.assertDoesNotThrow(() -> runner.assertPartialReleaseAllowed(config("lts/1.2.3", true, false, true)));
+        // full release from main with the flag is allowed
+        Assertions.assertDoesNotThrow(() -> runner.assertPartialReleaseAllowed(config("main", true, false, false)));
+    }
+}

--- a/maven-bulk-release/src/test/java/org/qubership/cloud/actions/maven/SwitchInterModuleDepsToSnapshotE2ETest.java
+++ b/maven-bulk-release/src/test/java/org/qubership/cloud/actions/maven/SwitchInterModuleDepsToSnapshotE2ETest.java
@@ -1,0 +1,151 @@
+package org.qubership.cloud.actions.maven;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+import org.qubership.cloud.actions.maven.model.*;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * End-to-end check that runs a real {@code mvn release:prepare} on a throwaway mini-monorepo and then
+ * exercises {@link ReleaseRunner#switchInterModuleDepsToSnapshot}. It verifies that the inter-module
+ * dependency is rewritten to the producer's real next development (SNAPSHOT) version taken from the
+ * genuine {@code release.properties} (project.dev.*) that maven-release-plugin produced.
+ * <p>
+ * Heavy (spawns real mvn subprocesses); gated behind {@code -De2e=true} so it does not run in the
+ * regular {@code mvn test}.
+ */
+@EnabledIfSystemProperty(named = "e2e", matches = "true")
+public class SwitchInterModuleDepsToSnapshotE2ETest {
+
+    static String producerPom(String scmUrl) {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.test</groupId>
+                    <artifactId>producer-lib</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <scm>
+                        <connection>%s</connection>
+                        <developerConnection>%s</developerConnection>
+                        <tag>HEAD</tag>
+                    </scm>
+                </project>""".formatted(scmUrl, scmUrl);
+    }
+
+    static String consumerPom(String scmUrl) {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.test</groupId>
+                    <artifactId>consumer-lib</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <properties>
+                        <test.producer-lib.version>1.0.0-SNAPSHOT</test.producer-lib.version>
+                    </properties>
+                    <scm>
+                        <connection>%s</connection>
+                        <developerConnection>%s</developerConnection>
+                        <tag>HEAD</tag>
+                    </scm>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.example.test</groupId>
+                            <artifactId>producer-lib</artifactId>
+                            <version>${test.producer-lib.version}</version>
+                            <type>pom</type>
+                        </dependency>
+                    </dependencies>
+                </project>""".formatted(scmUrl, scmUrl);
+    }
+
+    static RepositoryInfo repoInfo(Path baseDir, String pomFolder) {
+        RepositoryConfig cfg = RepositoryConfig.builder("https://localhost/test-mono")
+                .branch("main").pomFolder(pomFolder).build();
+        return new RepositoryInfo(cfg, baseDir.toString());
+    }
+
+    RepositoryRelease prepare(ReleaseRunner runner, Config config, RepositoryInfo repo, Set<GAV> deps) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            return runner.releasePrepare(config, repo, deps, out);
+        } catch (Exception e) {
+            System.out.println("=== release:prepare output for " + repo.getPomFolder() + " ===");
+            System.out.println(out.toString(StandardCharsets.UTF_8));
+            throw e;
+        }
+    }
+
+    @Test
+    void realReleasePrepareThenSwitchInterModuleDepsToSnapshot(@TempDir Path tmp) throws Exception {
+        Path baseDir = tmp.resolve("base");
+        Path repoRoot = baseDir.resolve("test-mono");
+        Files.createDirectories(repoRoot.resolve("producer"));
+        Files.createDirectories(repoRoot.resolve("consumer"));
+
+        Path bare = tmp.resolve("origin.git");
+        Git.init().setBare(true).setDirectory(bare.toFile()).call().close();
+        String scmUrl = "scm:git:file:///" + bare.toString().replace('\\', '/');
+
+        Files.writeString(repoRoot.resolve("producer/pom.xml"), producerPom(scmUrl));
+        Files.writeString(repoRoot.resolve("consumer/pom.xml"), consumerPom(scmUrl));
+
+        try (Git git = Git.init().setInitialBranch("main").setDirectory(repoRoot.toFile()).call()) {
+            StoredConfig gitCfg = git.getRepository().getConfig();
+            gitCfg.setString("remote", "origin", "url", bare.toString().replace('\\', '/'));
+            gitCfg.setString("user", null, "name", "t");
+            gitCfg.setString("user", null, "email", "t@t");
+            gitCfg.save();
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage("init").setAuthor("t", "t@t").call();
+
+            RepositoryInfo producer = repoInfo(baseDir, "producer");
+            RepositoryInfo consumer = repoInfo(baseDir, "consumer");
+
+            String localRepo = System.getProperty("user.home") + "/.m2/repository";
+            Config config = Config.builder(baseDir.toString(),
+                            GitConfig.builder().url("https://localhost").username("t").email("t@t").password("p").build(),
+                            MavenConfig.builder().localRepositoryPath(localRepo).deployArtifacts(false).build(),
+                            List.of(RepositoryConfig.builder("https://localhost/test-mono").branch("main").build()))
+                    .skipTests(true)
+                    .dryRun(false)
+                    .switchInterModuleDepsToSnapshot(true)
+                    .build();
+
+            ReleaseRunner runner = new ReleaseRunner();
+
+            RepositoryRelease producerRelease = prepare(runner, config, producer, Set.of());
+            GAV producerReleasedGav = producerRelease.getGavs().stream()
+                    .filter(g -> "producer-lib".equals(g.getArtifactId())).findFirst().orElseThrow();
+            RepositoryRelease consumerRelease = prepare(runner, config, consumer, Set.of(producerReleasedGav));
+
+            String producerDevVersion = producerRelease.getDevGavs().stream()
+                    .filter(g -> "producer-lib".equals(g.getArtifactId())).findFirst().orElseThrow().getVersion();
+            Assertions.assertTrue(producerDevVersion.endsWith("-SNAPSHOT"),
+                    "producer dev version from release.properties must be a SNAPSHOT, was: " + producerDevVersion);
+
+            runner.switchInterModuleDepsToSnapshot(config, List.of(producerRelease, consumerRelease));
+
+            String consumerPom = Files.readString(repoRoot.resolve("consumer/pom.xml"));
+            Assertions.assertTrue(
+                    consumerPom.contains("<test.producer-lib.version>" + producerDevVersion + "</test.producer-lib.version>"),
+                    "consumer property must point to producer's real dev SNAPSHOT (" + producerDevVersion + "), pom was:\n" + consumerPom);
+
+            String lastMessage = git.log().setMaxCount(1).call().iterator().next().getShortMessage();
+            Assertions.assertEquals("switch inter-module deps to SNAPSHOT after release", lastMessage);
+        }
+    }
+}

--- a/maven-bulk-release/src/test/java/org/qubership/cloud/actions/maven/SwitchInterModuleDepsToSnapshotTest.java
+++ b/maven-bulk-release/src/test/java/org/qubership/cloud/actions/maven/SwitchInterModuleDepsToSnapshotTest.java
@@ -1,0 +1,93 @@
+package org.qubership.cloud.actions.maven;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.qubership.cloud.actions.maven.model.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class SwitchInterModuleDepsToSnapshotTest {
+
+    static final String PRODUCER_POM = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example.test</groupId>
+                <artifactId>producer-lib</artifactId>
+                <version>1.0.1-SNAPSHOT</version>
+            </project>""";
+
+    static final String CONSUMER_POM = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example.test</groupId>
+                <artifactId>consumer-lib</artifactId>
+                <version>2.0.1-SNAPSHOT</version>
+                <properties>
+                    <test.producer-lib.version>1.0.0</test.producer-lib.version>
+                </properties>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.example.test</groupId>
+                        <artifactId>producer-lib</artifactId>
+                        <version>${test.producer-lib.version}</version>
+                    </dependency>
+                </dependencies>
+            </project>""";
+
+    static RepositoryInfo repoInfo(Path baseDir, String pomFolder) {
+        RepositoryConfig cfg = RepositoryConfig.builder("https://github.com/test/mono")
+                .branch("main").pomFolder(pomFolder).build();
+        return new RepositoryInfo(cfg, baseDir.toString());
+    }
+
+    static RepositoryRelease release(RepositoryInfo ri, String releasedVersion, String devVersion) {
+        RepositoryRelease r = new RepositoryRelease();
+        r.setRepository(ri);
+        r.setVersionTag(new VersionTag(releasedVersion, releasedVersion));
+        String ga = ri.getBaseModule().getGroupId() + ":" + ri.getBaseModule().getArtifactId();
+        r.setGavs(List.of(new GAV(ga + ":" + releasedVersion)));
+        r.setDevGavs(List.of(new GAV(ga + ":" + devVersion)));
+        return r;
+    }
+
+    @Test
+    void rewritesInterModulePropertyToSnapshotAndCommits(@TempDir Path baseDir) throws Exception {
+        Path repoRoot = baseDir.resolve("test/mono");
+        Files.createDirectories(repoRoot.resolve("producer"));
+        Files.createDirectories(repoRoot.resolve("consumer"));
+        Files.writeString(repoRoot.resolve("producer/pom.xml"), PRODUCER_POM);
+        Files.writeString(repoRoot.resolve("consumer/pom.xml"), CONSUMER_POM);
+
+        try (Git git = Git.init().setInitialBranch("main").setDirectory(repoRoot.toFile()).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage("init").setAuthor("t", "t@t").call();
+
+            RepositoryInfo producer = repoInfo(baseDir, "producer");
+            RepositoryInfo consumer = repoInfo(baseDir, "consumer");
+
+            Config config = ReleaseRunnerSnapshotTest.config("main", true, false, false);
+            List<RepositoryRelease> allReleases = List.of(
+                    release(producer, "1.0.0", "1.0.1-SNAPSHOT"),
+                    release(consumer, "2.0.0", "2.0.1-SNAPSHOT"));
+
+            new ReleaseRunner().switchInterModuleDepsToSnapshot(config, allReleases);
+
+            String consumerPom = Files.readString(repoRoot.resolve("consumer/pom.xml"));
+            Assertions.assertTrue(consumerPom.contains("<test.producer-lib.version>1.0.1-SNAPSHOT</test.producer-lib.version>"),
+                    "consumer property must point to producer's SNAPSHOT dev version");
+
+            String producerPom = Files.readString(repoRoot.resolve("producer/pom.xml"));
+            Assertions.assertTrue(producerPom.contains("<version>1.0.1-SNAPSHOT</version>"),
+                    "producer's own module version must stay untouched");
+
+            String lastMessage = git.log().setMaxCount(1).call().iterator().next().getShortMessage();
+            Assertions.assertEquals("switch inter-module deps to SNAPSHOT after release", lastMessage);
+        }
+    }
+}


### PR DESCRIPTION
**What changed.** Added an opt-in post-release step: after a full release from the `main`, inter-module dependencies are switched back to SNAPSHOT versions so development continues against SNAPSHOTs.

**When it runs.** Only for a full release from the `main` branch, never in dry-run. Enabled by a CLI flag `--switchInterModuleDepsToSnapshot`; off by default.

**What it does.** After all modules are released, it rewrites each module's dependencies on other released modules to their next SNAPSHOT version and commits that to the `main`. It does not affect what gets published — released (non-SNAPSHOT) artifacts are still deployed.

**Guardrail.** Partial releases from the trunk are rejected when the flag is on (partial releases allowed only from LTS branches).

**Side fix.** Made pom discovery work correctly on Windows.

**Tests.** Unit tests for the enable/guard conditions; an integration test for the actual rewrite; a heavy end-to-end test behind a manual flag.

**CI.** Generalized `run-e2e-tests.yml` workflow that runs all e2e tests on demand.